### PR TITLE
AOT friendly: instrumentStore() and _createExtensionOptions()

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -62,7 +62,9 @@ export function _createReducerIfExtension(extension: any, injector: Injector) {
 export function _createExtensionOptions(): StoreDevtoolsConfig {
   return {
     maxAge: Infinity,
-    monitor: () => null
+    monitor: function() {
+      return null;
+    }
   };
 }
 
@@ -83,7 +85,9 @@ export function _createExtensionOptions(): StoreDevtoolsConfig {
 export class StoreDevtoolsModule {
   static instrumentStore(_options: StoreDevtoolsConfig = {}) {
     const DEFAULT_OPTIONS: StoreDevtoolsConfig = {
-      monitor: () => null
+      monitor: function() {
+        return null;
+      }
     };
 
     const options = Object.assign({}, DEFAULT_OPTIONS, _options);


### PR DESCRIPTION
Fixes #48 StoreDevtoolsModule.instrumentStore not compatible with Ahead of time compilation.

No new functionality added. 
No new tests added. 

All specs passing.

```
> nyc node tests.js

Started
........................


24 specs, 0 failures
Finished in 1.127 seconds

---------------|----------|----------|----------|----------|----------------|
File           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------|----------|----------|----------|----------|----------------|
All files      |    84.45 |    71.79 |    68.57 |    85.62 |                |
 actions.ts    |    85.71 |       50 |    88.89 |    85.71 |          48,49 |
 config.ts     |      100 |      100 |      100 |      100 |                |
 devtools.ts   |    96.83 |      100 |    76.47 |    96.43 |          80,88 |
 extension.ts  |    71.15 |    33.33 |    31.25 |    76.74 |... 5,90,91,103 |
 instrument.ts |       62 |       50 |    58.33 |    59.57 |... 8,63,65,114 |
 reducer.ts    |     90.7 |       86 |      100 |    92.68 |... 217,221,222 |
 utils.ts      |    94.44 |      100 |    85.71 |    92.86 |             21 |
---------------|----------|----------|----------|----------|----------------|
```
