### PR TITLE
Add support for LOCK_CHANGES actions

### DIFF
--- a/spec/store.spec.ts
+++ b/spec/store.spec.ts
@@ -560,7 +560,7 @@ describe('Store Devtools', () => {
     it('should lock', () => {
       fixture.store.dispatch({ type: 'INCREMENT' });
       fixture.devtools.lockChanges(true);
-      expect(fixture.getLiftedState().dropNewActions).toBe(true);
+      expect(fixture.getLiftedState().isLocked).toBe(true);
       expect(fixture.getLiftedState().nextActionId).toBe(2);
       expect(fixture.getState()).toBe(1);
 
@@ -574,7 +574,7 @@ describe('Store Devtools', () => {
       expect(fixture.getState()).toBe(1);
 
       fixture.devtools.lockChanges(false);
-      expect(fixture.getLiftedState().dropNewActions).toBe(false);
+      expect(fixture.getLiftedState().isLocked).toBe(false);
       expect(fixture.getLiftedState().nextActionId).toBe(2);
 
       fixture.store.dispatch({ type: 'INCREMENT' });

--- a/spec/store.spec.ts
+++ b/spec/store.spec.ts
@@ -545,4 +545,41 @@ describe('Store Devtools', () => {
       expect(fixture.getLiftedState()).toEqual(exportedState);
     });
   });
+
+  describe('Lock Changes', () => {
+    let fixture: Fixture<number>;
+
+    beforeEach(() => {
+      fixture = createStore(counter);
+    });
+
+    afterEach(() => {
+      fixture.cleanup();
+    });
+
+    it('should lock', () => {
+      fixture.store.dispatch({ type: 'INCREMENT' });
+      fixture.devtools.lockChanges(true);
+      expect(fixture.getLiftedState().dropNewActions).toBe(true);
+      expect(fixture.getLiftedState().nextActionId).toBe(2);
+      expect(fixture.getState()).toBe(1);
+
+      fixture.store.dispatch({ type: 'INCREMENT' });
+      expect(fixture.getLiftedState().nextActionId).toBe(2);
+      expect(fixture.getState()).toBe(1);
+
+      fixture.devtools.toggleAction(1);
+      expect(fixture.getState()).toBe(0);
+      fixture.devtools.toggleAction(1);
+      expect(fixture.getState()).toBe(1);
+
+      fixture.devtools.lockChanges(false);
+      expect(fixture.getLiftedState().dropNewActions).toBe(false);
+      expect(fixture.getLiftedState().nextActionId).toBe(2);
+
+      fixture.store.dispatch({ type: 'INCREMENT' });
+      expect(fixture.getLiftedState().nextActionId).toBe(3);
+      expect(fixture.getState()).toBe(2);
+    });
+  });
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,7 +7,8 @@ export const ActionTypes = {
   TOGGLE_ACTION: 'TOGGLE_ACTION',
   SET_ACTIONS_ACTIVE: 'SET_ACTIONS_ACTIVE',
   JUMP_TO_STATE: 'JUMP_TO_STATE',
-  IMPORT_STATE: 'IMPORT_STATE'
+  IMPORT_STATE: 'IMPORT_STATE',
+  LOCK_CHANGES: 'LOCK_CHANGES',
 };
 
 /**
@@ -55,5 +56,9 @@ export const StoreDevtoolActions = {
 
   importState(nextLiftedState) {
     return { type: ActionTypes.IMPORT_STATE, nextLiftedState };
-  }
+  },
+
+  lockChanges(status) {
+    return { type: ActionTypes.LOCK_CHANGES, status };
+  },
 };

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -115,4 +115,8 @@ export class StoreDevtools implements Observer<any> {
   importState(nextLiftedState: any) {
     this.dispatch(actions.importState(nextLiftedState));
   }
+
+  lockChanges(status: any) {
+    this.dispatch(actions.lockChanges(status));
+  }
 }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -51,7 +51,7 @@ export class StoreDevtools implements Observer<any> {
 
     const liftedReducer$ = map.call(reducers$, liftReducer);
 
-    const liftedStateSubject = new ReplaySubject(1);
+    const liftedStateSubject = new ReplaySubject<LiftedState>(1);
     const liftedStateSubscription = applyOperators(liftedAction$, [
       [ withLatestFrom, liftedReducer$ ],
       [ scan, (liftedState, [ action, reducer ]) => {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -15,7 +15,7 @@ export interface LiftedState {
   committedState: any;
   currentStateIndex: number;
   computedStates: { state: any, error: any }[];
-  dropNewActions: boolean;
+  isLocked: boolean;
 }
 
 /**
@@ -95,7 +95,7 @@ export function liftInitialState(initialCommittedState?: any, monitorReducer?: a
     committedState: initialCommittedState,
     currentStateIndex: 0,
     computedStates: [],
-    dropNewActions: false,
+    isLocked: false,
   };
 }
 
@@ -121,7 +121,7 @@ export function liftReducerWith(
       committedState,
       currentStateIndex,
       computedStates,
-      dropNewActions,
+      isLocked,
     } = liftedState || initialLiftedState;
 
     if (!liftedState) {
@@ -240,7 +240,7 @@ export function liftReducerWith(
         break;
       }
       case ActionTypes.PERFORM_ACTION: {
-        if (dropNewActions) {
+        if (isLocked) {
           return liftedState || initialLiftedState;
         }
 
@@ -276,7 +276,7 @@ export function liftReducerWith(
         break;
       }
       case ActionTypes.LOCK_CHANGES: {
-        dropNewActions = liftedAction.status;
+        isLocked = liftedAction.status;
         minInvalidatedStateIndex = Infinity;
         break;
       }
@@ -333,7 +333,7 @@ export function liftReducerWith(
       committedState,
       currentStateIndex,
       computedStates,
-      dropNewActions,
+      isLocked,
     };
   };
 }


### PR DESCRIPTION
Hi. One feature I really wanted to see in the ngrx devtools is support for locking changes, since it improves the time-travel debugging experience quite a lot.

First of all, please note that this PR is not complete yet. See below for open points.

The code from this PR is copied mostly from the [redux-devtools-instrument](https://github.com/zalmoxisus/redux-devtools-instrument) repo. I just had to made some slight changes. As far as I can see everything works as expected, but I couldn't really use it yet for a project due to the issue below.

#### Open point

I have not yet found out how to notify the monitor (personally I am using the chrome extension) that the lock state changed. Therefore, currently the monitor will always send the `LOCK_CHANGES` action with status `true` making the store locked indefinitely. The monitor UI also doesn't update to reflect the change. I am hoping some of you will be able to help me figuring out how this should be done.