### PR TITLE
adding missing peer depenedencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "homepage": "https://github.com/ngrx/devtools#readme",
   "peerDependencies": {
     "@ngrx/store": "^2.0.0",
-    "rxjs": "^5.0.0-beta.12"
+    "rxjs": "^5.0.0-beta.12",
+    "@angular/core": "^4.0.0"
   },
   "devDependencies": {
     "@angular/animations": "^4.0.0",


### PR DESCRIPTION
I had some small issue with my webpack plugin that checks for peer dependencies. Basically this lib requires @angular/core as peer dep so i have added it. 